### PR TITLE
Fix: Sensor/Actuator assignment changes after update

### DIFF
--- a/xs1_api_client/api.py
+++ b/xs1_api_client/api.py
@@ -456,9 +456,12 @@ class XS1:
         response = self.call_api(Command.GET_LIST_SENSORS)
 
         all_sensors = []
+        sensor_number = 1
         for sensor in self._get_node_value(response, Node.SENSOR):
+            sensor["number"] = sensor_number
             device = XS1Sensor(sensor, self)
             all_sensors.append(device)
+            sensor_number += 1
 
         if enabled is None:
             return all_sensors

--- a/xs1_api_client/api.py
+++ b/xs1_api_client/api.py
@@ -412,8 +412,10 @@ class XS1:
         response = self.call_api(Command.GET_LIST_ACTUATORS)
 
         all_actuators = []
+        actuator_number = 1
         # create actuator objects
         for actuator in self._get_node_value(response, Node.ACTUATOR):
+            actuator["number"] = actuator_number
             actuator_type = self._get_node_value(actuator, Node.PARAM_TYPE)
             if ActuatorType.SWITCH == actuator_type or ActuatorType.DIMMER == actuator_type:
                 device = XS1Switch(actuator, self)
@@ -421,6 +423,7 @@ class XS1:
                 device = XS1Actuator(actuator, self)
 
             all_actuators.append(device)
+            actuator_number += 1
 
         if enabled is None:
             return all_actuators


### PR DESCRIPTION
Fixes #1

Its injecting the "number" State Field directly on the first get_all_sensors(). So id() is not getting crazy about id and number

For me this fixes the Sensor assigments in Home Assistent.
I didnt tested the Actuators, but implemented the same Hack.

@markusressel can you please run the unit tests against your xs1 device?



