### PR TITLE
Bugfix/#1 assignment changes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,18 @@ The initial goal of this library was to be able to integrate the EZcontrol® XS1
 You can find the related integration documentation here: 
 `XS1 Home Assistant component documentation <https://www.home-assistant.io/components/xs1/>`_
 
+Note:
+xs1-api-client was designed to have reusable device objects, meaning device objects can be updated.
+When a user changes the order of devices within the XS1 gateway, their ids don't change but their numbers (orders) do.
+This causes the "device object" <-> device id association to get messed up. Since there is no way for us to know
+about this change, it's impossible for us to tell that the device number we use for an already created device object
+does not correspond to the correct device anymore without fetching all devices again, which requires the recreation
+of all device objects.
+
+**TL;DR:**
+**Do not change the order of the devices in the XS1 Gateway** if you can avoid it, and if you do,
+restart the service that relies on xs1-api-client to force a re-fetch of all devices.
+
 How to use
 ==========
 

--- a/example_config.py
+++ b/example_config.py
@@ -36,10 +36,10 @@ print("")
 # this is a simple example to change the name of an existing actuator configuration
 # by using the RAW API method
 # there is also a much simpler version of this, seen below
-actuator_id_to_change = 17
+actuator_number_to_change = 17
 
 # retrieve the current configuration
-current_config = api.get_config_actuator(actuator_id_to_change)
+current_config = api.get_config_actuator(actuator_number_to_change)
 
 print(current_config)
 print("")
@@ -49,7 +49,7 @@ new_config = current_config.copy()
 new_config[UrlParam.NAME] = "My_new_name" + str(randint(0, 9))
 
 # set the changed configuration and print the result of the request
-print(api.set_config_actuator(actuator_id_to_change, new_config))
+print(api.set_config_actuator(actuator_number_to_change, new_config))
 
 # you can also use convenience methods directly on the actuators and sensors
 actuator = api.get_actuator(35)

--- a/example_config_copy_actuator.py
+++ b/example_config_copy_actuator.py
@@ -112,13 +112,13 @@ my_config[UrlParam.FUNCTION] = [
 # ATTENTION: This will (if successful) overwrite any existing configuration!
 # Make a BACKUP!
 
-actuator_id_to_copy = 30
-target_id = 31
+actuator_number_to_copy = 30
+target_number = 31
 
-api.set_config_actuator(target_id, my_config)
+api.set_config_actuator(target_number, my_config)
 
 # retrieve the current configuration
-configuration = api.get_config_actuator(actuator_id_to_copy)
+configuration = api.get_config_actuator(actuator_number_to_copy)
 
 print("Source: " + str(configuration))
 print("")
@@ -128,10 +128,10 @@ copy = configuration.copy()
 copy[UrlParam.NAME.value] = "Actuator_30_CPY"
 
 # set the changed configuration
-api.set_config_actuator(target_id, copy)
+api.set_config_actuator(target_number, copy)
 
 # print the new state
-print("Target: " + str(api.get_config_actuator(target_id)))
+print("Target: " + str(api.get_config_actuator(target_number)))
 
 
 # print(api.set_config_actuator(actuator_id_to_change, my_config))

--- a/xs1_api_client/api.py
+++ b/xs1_api_client/api.py
@@ -443,63 +443,63 @@ class XS1:
                 filtered_sensors.append(sensor)
             return filtered_sensors
 
-    def get_state_actuator(self, actuator_id: int) -> dict:
+    def get_state_actuator(self, actuator_number: int) -> dict:
         """
         Gets the current state of the specified actuator.
-        :param actuator_id: actuator id
+        :param actuator_number: actuator number (not id!)
         :return: the api response as a dict
         """
         return self.call_api(Command.GET_STATE_ACTUATOR,
-                             {UrlParam.NUMBER: actuator_id})
+                             {UrlParam.NUMBER: actuator_number})
 
-    def get_state_sensor(self, sensor_id: int) -> dict:
+    def get_state_sensor(self, sensor_number: int) -> dict:
         """
         Gets the current state of the specified sensor.
-        :param sensor_id: sensor id
+        :param sensor_number: sensor number (not id!)
         :return: the api response as a dict
         """
         return self.call_api(Command.GET_STATE_SENSOR,
                              {
-                                 UrlParam.NUMBER: sensor_id,
+                                 UrlParam.NUMBER: sensor_number,
                              })
 
-    def call_actuator_function(self, actuator_id: int, function) -> dict:
+    def call_actuator_function(self, actuator_number: int, function) -> dict:
         """
         Executes a function on the specified actuator and sets the response on the passed in actuator.
-        :param actuator_id: actuator id to execute the function on and set response value
+        :param actuator_number: actuator number (not id!) to execute the function on and set response value
         :param function: id of the function to execute
         :return: the api response
         """
         return self.call_api(Command.SET_STATE_ACTUATOR,
                              {
-                                 UrlParam.NUMBER: actuator_id,
+                                 UrlParam.NUMBER: actuator_number,
                                  UrlParam.FUNCTION: function
                              })
 
-    def set_actuator_value(self, actuator_id: int, value) -> dict:
+    def set_actuator_value(self, actuator_number: int, value) -> dict:
         """
         Sets a new value for the specified actuator.
-        :param actuator_id: actuator id to set the new value on
+        :param actuator_number: actuator number (not id!) to set the new value on
         :param value: the new value to set on the specified actuator
         :return: the api response
         """
         return self.call_api(Command.SET_STATE_ACTUATOR,
                              {
-                                 UrlParam.NUMBER: actuator_id,
+                                 UrlParam.NUMBER: actuator_number,
                                  UrlParam.VALUE: value
                              })
 
-    def set_sensor_value(self, sensor_id: int, value) -> dict:
+    def set_sensor_value(self, sensor_number: int, value) -> dict:
         """
         Sets a new value for the specified sensor.
         WARNING: Only use this for "virtual" sensors or for debugging!
-        :param sensor_id: sensor id to set the new value on
+        :param sensor_number: sensor number (not id!) to set the new value on
         :param value: the new value to set on the specified sensor
         :return: the api response
         """
         return self.call_api(Command.SET_STATE_SENSOR,
                              {
-                                 UrlParam.NUMBER: sensor_id,
+                                 UrlParam.NUMBER: sensor_number,
                                  UrlParam.VALUE: value
                              })
 

--- a/xs1_api_client/api.py
+++ b/xs1_api_client/api.py
@@ -295,34 +295,40 @@ class XS1:
         response = self.call_api(Command.GET_TYPES_SENSORS)
         return self._get_node_value(response, "sensortype")
 
-    def get_config_actuator(self, actuator_id: int) -> dict:
+    def get_config_actuator(self, number: int) -> dict:
         """
+        :param number: number of the actuator
         :return: the configuration of a specific actuator
         """
-        response = self.call_api(Command.GET_CONFIG_ACTUATOR, {UrlParam.NUMBER: actuator_id})
+        response = self.call_api(Command.GET_CONFIG_ACTUATOR, {UrlParam.NUMBER: number})
         return self._get_node_value(response, Node.ACTUATOR)
 
-    def set_config_actuator(self, actuator_id: int, configuration: dict) -> dict:
+    def set_config_actuator(self, number: int, configuration: dict) -> dict:
         """
-        :return: the configuration of a specific actuator
+        :param number: number of the actuator
+        :param configuration: actuator configuration
+        :return: the new configuration of the specific actuator
         """
-        configuration[UrlParam.NUMBER] = actuator_id
+        configuration[UrlParam.NUMBER] = number
 
         response = self.call_api(Command.SET_CONFIG_ACTUATOR, configuration)
         return self._get_node_value(response, Node.ACTUATOR)
 
-    def get_config_sensor(self, sensor_id: int) -> dict:
+    def get_config_sensor(self, number: int) -> dict:
         """
-        :return: the configuration of a specific sensor
+        :param number: number of the sensor
+        :return: the configuration of the specific sensor
         """
-        response = self.call_api(Command.GET_CONFIG_SENSOR, {UrlParam.NUMBER: sensor_id})
+        response = self.call_api(Command.GET_CONFIG_SENSOR, {UrlParam.NUMBER: number})
         return self._get_node_value(response, Node.SENSOR)
 
-    def set_config_sensor(self, sensor_id: int, configuration: dict) -> dict:
+    def set_config_sensor(self, number: int, configuration: dict) -> dict:
         """
-        :return: the configuration of a specific actuator
+        :param number: number of the actuator
+        :param configuration: sensor configuration
+        :return: the new configuration of the sensor
         """
-        configuration[UrlParam.NUMBER.value] = sensor_id
+        configuration[UrlParam.NUMBER.value] = number
 
         response = self.call_api(Command.SET_CONFIG_SENSOR, configuration)
         return self._get_node_value(response, Node.SENSOR)
@@ -379,6 +385,19 @@ class XS1:
 
         return None
 
+    def get_actuator_by_number(self, number: int) -> XS1Actuator or None:
+        """
+        Get an actuator with a specific number
+        :param number: the number of the actuator
+        :return: XS1Actuator
+        """
+        all_actuators = self.get_all_actuators()
+        for actuator in all_actuators:
+            if actuator.number() == number:
+                return actuator
+
+        return None
+
     def get_all_actuators(self, enabled: bool or None = None) -> [XS1Actuator]:
         """
         Requests the list of enabled actuators from the gateway.
@@ -389,7 +408,10 @@ class XS1:
 
         all_actuators = []
         # create actuator objects
-        for actuator in self._get_node_value(response, Node.ACTUATOR):
+        for idx, actuator in enumerate(self._get_node_value(response, Node.ACTUATOR), start=1):
+            # attach number to data so we can use it for future requests
+            actuator[Node.PARAM_NUMBER.value] = idx
+
             actuator_type = self._get_node_value(actuator, Node.PARAM_TYPE)
             if ActuatorType.SWITCH == actuator_type or ActuatorType.DIMMER == actuator_type:
                 device = XS1Switch(actuator, self)
@@ -411,12 +433,25 @@ class XS1:
     def get_sensor(self, sensor_id: int) -> XS1Sensor or None:
         """
         Get a sensor with a specific id
-        :param sensor_id: the id of the actuator
+        :param sensor_id: the id of the sensor
         :return: XS1Sensor
         """
         all_sensors = self.get_all_sensors()
         for sensor in all_sensors:
             if sensor.id() == sensor_id:
+                return sensor
+
+        return None
+
+    def get_sensor_by_number(self, number: int) -> XS1Sensor or None:
+        """
+        Get a sensor with a specific id
+        :param number: the number of the sensor
+        :return: XS1Sensor
+        """
+        all_sensors = self.get_all_sensors()
+        for sensor in all_sensors:
+            if sensor.number() == number:
                 return sensor
 
         return None
@@ -429,7 +464,9 @@ class XS1:
         response = self.call_api(Command.GET_LIST_SENSORS)
 
         all_sensors = []
-        for sensor in self._get_node_value(response, Node.SENSOR):
+        for idx, sensor in enumerate(self._get_node_value(response, Node.SENSOR), start=1):
+            # attach number to data so we can use it for future requests
+            sensor[Node.PARAM_NUMBER.value] = idx
             device = XS1Sensor(sensor, self)
             all_sensors.append(device)
 

--- a/xs1_api_client/api.py
+++ b/xs1_api_client/api.py
@@ -408,9 +408,9 @@ class XS1:
 
         all_actuators = []
         # create actuator objects
-        for idx, actuator in enumerate(self._get_node_value(response, Node.ACTUATOR), start=1):
+        for number, actuator in enumerate(self._get_node_value(response, Node.ACTUATOR), start=1):
             # attach number to data so we can use it for future requests
-            actuator[Node.PARAM_NUMBER.value] = idx
+            actuator[Node.PARAM_NUMBER.value] = number
 
             actuator_type = self._get_node_value(actuator, Node.PARAM_TYPE)
             if ActuatorType.SWITCH == actuator_type or ActuatorType.DIMMER == actuator_type:
@@ -464,9 +464,9 @@ class XS1:
         response = self.call_api(Command.GET_LIST_SENSORS)
 
         all_sensors = []
-        for idx, sensor in enumerate(self._get_node_value(response, Node.SENSOR), start=1):
+        for number, sensor in enumerate(self._get_node_value(response, Node.SENSOR), start=1):
             # attach number to data so we can use it for future requests
-            sensor[Node.PARAM_NUMBER.value] = idx
+            sensor[Node.PARAM_NUMBER.value] = number
             device = XS1Sensor(sensor, self)
             all_sensors.append(device)
 

--- a/xs1_api_client/api.py
+++ b/xs1_api_client/api.py
@@ -21,7 +21,6 @@ class XS1:
     """
     This class is the main api interface that handles all communication with the XS1 gateway.
     """
-
     # setup retry and backoff strategy
     RETRY_STRATEGY = Retry(total=5,
                            backoff_factor=0.1,
@@ -34,18 +33,16 @@ class XS1:
     _password = None
     _config_info = None
 
-    def __init__(self, host: str = None, port: int = 80, ssl: bool = False, user: str = None,
+    def __init__(self, host: str = None, port: int or None = 80, ssl: bool = False, user: str = None,
                  password: str = None) -> None:
         """
         Creates a new api object.
-
         :param host: host address of the gateway api
         :param port: host port of the gateway api
         :param ssl: uses HTTPS instead of HTTP if set to True
         :param user: username for authentication
         :param password: password for authentication
         """
-
         self.set_connection_info(host, port, ssl, user, password)
 
     def set_connection_info(self, host: str, port: int = None, ssl: bool = False, user: str = None,
@@ -53,14 +50,12 @@ class XS1:
         """
         Sets private connection info for this XS1 instance.
         This XS1 instance will also immediately use this connection info.
-
         :param host: host address of the gateway api
         :param port: host port of the gateway api
         :param ssl: uses HTTPS instead of HTTP if set to True
         :param user: username for authentication
         :param password: password for authentication
         """
-
         self._host = host
         self._port = port
         self._ssl = ssl
@@ -74,32 +69,27 @@ class XS1:
         """
         :return: the currently set host address
         """
-
         return self._host
 
     def get_user(self) -> str or None:
         """
         :return: the currently set user used for authentication
         """
-
         return self._user
 
     def get_password(self) -> str or None:
         """
         :return: the currently set password used for authentication
         """
-
         return self._password
 
     def call_api(self, command: Command, parameters: dict = None) -> dict:
         """
         Executes a command on the xs1 api and returns it's response as a dictionary (if there was no error).
-
         :param command: command parameter for the URL (see api_constants)
         :param parameters: additional parameters needed for the specified command like 'number=3' passed in as a dictionary
         :return: the api response
         """
-
         request_url = self._build_request_url(command, parameters, self._ssl)
         response = self._send_request(request_url)
 
@@ -111,13 +101,11 @@ class XS1:
     def _build_request_url(self, command: Command, parameters: dict = None, ssl: bool = False) -> str:
         """
         Builds a request url from the input parameters
-
         :param command: the main command
         :param parameters: additional parameters
         :param ssl: Uses HTTPS instead of HTTP
         :return: request url
         """
-
         if not self._host:
             raise Exception("Missing host!")
 
@@ -152,7 +140,6 @@ class XS1:
             def process_parameters(params: dict) -> dict:
                 """
                 Removes duplicates and replaces ApiConstants (Enums) with it's value
-
                 :param params: parameters to process
                 :return: cleaned up parameters
                 """
@@ -206,11 +193,9 @@ class XS1:
     def _send_request(self, request_url: str) -> dict:
         """
         Sends a GET request to the XS1 Gateway and returns the response as a JSON object.
-
         :param request_url: the request url
         :return: the api response as a json object
         """
-
         # create session
         with requests.Session() as session:
             if self._ssl:
@@ -233,13 +218,11 @@ class XS1:
         """
         Checks the response dict for errors.
         Does nothing if no error is detected
-
         :param command: the command used for the request
         :param parameters: parameters used for the request
         :param response: the api response json
         :return: the api response if no error is detected, raises an exception otherwise
         """
-
         error = self._get_node_value(response, Node.ERROR)
         if error:
             # try to map error code to one of the known error values
@@ -266,10 +249,8 @@ class XS1:
     def get_protocol_info(self) -> str:
         """
         Retrieves the protocol version that is used by the gateway
-
         :return: protocol version number
         """
-
         response = self.call_api(Command.GET_PROTOCOL_INFO)
         return self._get_node_value(response, Node.VERSION)
 
@@ -325,7 +306,6 @@ class XS1:
         """
         :return: the configuration of a specific actuator
         """
-
         configuration[UrlParam.NUMBER] = actuator_id
 
         response = self.call_api(Command.SET_CONFIG_ACTUATOR, configuration)
@@ -342,7 +322,6 @@ class XS1:
         """
         :return: the configuration of a specific actuator
         """
-
         configuration[UrlParam.NUMBER.value] = sensor_id
 
         response = self.call_api(Command.SET_CONFIG_SENSOR, configuration)
@@ -393,7 +372,6 @@ class XS1:
         :param actuator_id: the id of the actuator
         :return: XS1Actuator
         """
-
         all_actuators = self.get_all_actuators()
         for actuator in all_actuators:
             if actuator.id() == actuator_id:
@@ -404,11 +382,9 @@ class XS1:
     def get_all_actuators(self, enabled: bool or None = None) -> [XS1Actuator]:
         """
         Requests the list of enabled actuators from the gateway.
-
         :param enabled:
         :return: a list of XS1Actuator objects
         """
-
         response = self.call_api(Command.GET_LIST_ACTUATORS)
 
         all_actuators = []
@@ -438,7 +414,6 @@ class XS1:
         :param sensor_id: the id of the actuator
         :return: XS1Sensor
         """
-
         all_sensors = self.get_all_sensors()
         for sensor in all_sensors:
             if sensor.id() == sensor_id:
@@ -449,10 +424,8 @@ class XS1:
     def get_all_sensors(self, enabled: bool or None = None) -> [XS1Sensor]:
         """
         Requests the list of enabled sensors from the gateway.
-
         :return: list of XS1Sensor objects
         """
-
         response = self.call_api(Command.GET_LIST_SENSORS)
 
         all_sensors = []
@@ -473,7 +446,6 @@ class XS1:
     def get_state_actuator(self, actuator_id: int) -> dict:
         """
         Gets the current state of the specified actuator.
-
         :param actuator_id: actuator id
         :return: the api response as a dict
         """
@@ -483,7 +455,6 @@ class XS1:
     def get_state_sensor(self, sensor_id: int) -> dict:
         """
         Gets the current state of the specified sensor.
-
         :param sensor_id: sensor id
         :return: the api response as a dict
         """
@@ -495,12 +466,10 @@ class XS1:
     def call_actuator_function(self, actuator_id: int, function) -> dict:
         """
         Executes a function on the specified actuator and sets the response on the passed in actuator.
-
         :param actuator_id: actuator id to execute the function on and set response value
         :param function: id of the function to execute
         :return: the api response
         """
-
         return self.call_api(Command.SET_STATE_ACTUATOR,
                              {
                                  UrlParam.NUMBER: actuator_id,
@@ -510,12 +479,10 @@ class XS1:
     def set_actuator_value(self, actuator_id: int, value) -> dict:
         """
         Sets a new value for the specified actuator.
-
         :param actuator_id: actuator id to set the new value on
         :param value: the new value to set on the specified actuator
         :return: the api response
         """
-
         return self.call_api(Command.SET_STATE_ACTUATOR,
                              {
                                  UrlParam.NUMBER: actuator_id,
@@ -526,12 +493,10 @@ class XS1:
         """
         Sets a new value for the specified sensor.
         WARNING: Only use this for "virtual" sensors or for debugging!
-
         :param sensor_id: sensor id to set the new value on
         :param value: the new value to set on the specified sensor
         :return: the api response
         """
-
         return self.call_api(Command.SET_STATE_SENSOR,
                              {
                                  UrlParam.NUMBER: sensor_id,
@@ -544,7 +509,6 @@ class XS1:
         :param node: the node to retrieve the value for
         :return: the value of this node or None if it doesn't exist
         """
-
         if isinstance(node, Node):
             node_name = node.value
         else:

--- a/xs1_api_client/api.py
+++ b/xs1_api_client/api.py
@@ -445,7 +445,7 @@ class XS1:
 
     def get_sensor_by_number(self, number: int) -> XS1Sensor or None:
         """
-        Get a sensor with a specific id
+        Get a sensor with a specific number
         :param number: the number of the sensor
         :return: XS1Sensor
         """

--- a/xs1_api_client/api_constants.py
+++ b/xs1_api_client/api_constants.py
@@ -45,7 +45,7 @@ class UrlParam(ApiConstant):
     """command parameter that specifies the method the api is queried with"""
 
     NUMBER = 'number'
-    """number parameter that specifies the id of an actuator or sensor"""
+    """number parameter that specifies the number of an actuator or sensor"""
 
     NAME = 'name'
 

--- a/xs1_api_client/device/__init__.py
+++ b/xs1_api_client/device/__init__.py
@@ -56,7 +56,6 @@ class XS1Device(object):
         """
         :return: the type of this device
         """
-
         device_type_string = self._get_node_value(self._state, Node.PARAM_TYPE)
 
         # try to convert string value to Enum constant

--- a/xs1_api_client/device/__init__.py
+++ b/xs1_api_client/device/__init__.py
@@ -47,10 +47,13 @@ class XS1Device(object):
         """
         :return: id of this device
         """
-        device_id = self._get_node_value(self._state, Node.PARAM_NUMBER)
-        if device_id is None:
-            device_id = self._get_node_value(self._state, Node.PARAM_ID)
-        return device_id
+        return self._get_node_value(self._state, Node.PARAM_ID)
+
+    def number(self) -> int:
+        """
+        :return: number of this device
+        """
+        return self._get_node_value(self._state, Node.PARAM_NUMBER)
 
     def type(self) -> ActuatorType or SensorType or str:
         """

--- a/xs1_api_client/device/__init__.py
+++ b/xs1_api_client/device/__init__.py
@@ -24,8 +24,9 @@ class XS1Device(object):
         """
         :return: String representation of this device
         """
-        return "%s (ID: %i, Enabled: %s, Type: %s, Value: %s, New Value: %s, Unit: %s)" % (
-            self.name(), self.id(), self.enabled(), self.type(), self.value(), self.new_value(), self.unit())
+        return "%s (ID: %i, Number: %i, Enabled: %s, Type: %s, Value: %s, New Value: %s, Unit: %s)" % (
+            self.name(), self.id(), self.number(), self.enabled(), self.type(), self.value(), self.new_value(),
+            self.unit())
 
     def set_state(self, new_state: dict) -> None:
         """

--- a/xs1_api_client/device/actuator/__init__.py
+++ b/xs1_api_client/device/actuator/__init__.py
@@ -25,7 +25,6 @@ class XS1Actuator(XS1Device):
         """
         Sets a new name for this device.
         Keep in mind that there are some limitations for a device name.
-
         :param name: the new name to set
         :return: the new name of the actuator
         """
@@ -51,7 +50,6 @@ class XS1Actuator(XS1Device):
     def set_value(self, value) -> None:
         """
         Sets a new value for this actuator
-
         :param value: new value to set
         """
         new_state = self._api_interface.set_actuator_value(self.id(), value)
@@ -107,7 +105,6 @@ class XS1Actuator(XS1Device):
     def call_function(self, xs1_function):
         """
         Calls the specified function by id and saves the api response as the new state
-
         :param xs1_function: XS1Function object
         """
         if not isinstance(xs1_function, XS1Function):

--- a/xs1_api_client/device/actuator/__init__.py
+++ b/xs1_api_client/device/actuator/__init__.py
@@ -17,7 +17,7 @@ class XS1Actuator(XS1Device):
         """
         Updates the state of this actuator
         """
-        response = self._api_interface.get_state_actuator(self.id())
+        response = self._api_interface.get_state_actuator(self.number())
         new_value = self._get_node_value(response, Node.ACTUATOR)
         self.set_state(new_value)
 
@@ -31,7 +31,7 @@ class XS1Actuator(XS1Device):
         # check name arg for validity
         super(XS1Actuator, self).set_name(name)
 
-        config = self._api_interface.get_config_actuator(self.id())
+        config = self._api_interface.get_config_actuator(self.number())
 
         # name is already set, to minimize flash writes don't write it again
         if config["name"] == name:
@@ -39,7 +39,7 @@ class XS1Actuator(XS1Device):
 
         config["name"] = name
 
-        result = self._api_interface.set_config_actuator(self.id(), config)
+        result = self._api_interface.set_config_actuator(self.number(), config)
         new_name = self._get_node_value(result, "name")
 
         # save new_name to internal state
@@ -52,7 +52,7 @@ class XS1Actuator(XS1Device):
         Sets a new value for this actuator
         :param value: new value to set
         """
-        new_state = self._api_interface.set_actuator_value(self.id(), value)
+        new_state = self._api_interface.set_actuator_value(self.number(), value)
         new_value = self._get_node_value(new_state, Node.ACTUATOR)
         self.set_state(new_value)
 

--- a/xs1_api_client/device/actuator/switch.py
+++ b/xs1_api_client/device/actuator/switch.py
@@ -13,12 +13,12 @@ class XS1Switch(XS1Actuator):
 
     def turn_on(self) -> None:
         """Turns on the switch."""
-        response = self._api_interface.set_actuator_value(self.id(), 100)
+        response = self._api_interface.set_actuator_value(self.number(), 100)
         new_value = self._get_node_value(response, Node.ACTUATOR)
         self.set_state(new_value)
 
     def turn_off(self) -> None:
         """Turns off the switch."""
-        response = self._api_interface.set_actuator_value(self.id(), 0)
+        response = self._api_interface.set_actuator_value(self.number(), 0)
         new_value = self._get_node_value(response, Node.ACTUATOR)
         self.set_state(new_value)

--- a/xs1_api_client/device/actuator/thermostat.py
+++ b/xs1_api_client/device/actuator/thermostat.py
@@ -15,6 +15,6 @@ class XS1Thermostat(XS1Actuator):
         Sets the new target temperature of this thermostat
         :param temp: new target temperature
         """
-        response = self._api_interface.set_actuator_value(self.id(), temp)
+        response = self._api_interface.set_actuator_value(self.number(), temp)
         new_value = self._get_node_value(response, Node.ACTUATOR)
         self.set_state(new_value)

--- a/xs1_api_client/device/actuator/thermostat.py
+++ b/xs1_api_client/device/actuator/thermostat.py
@@ -13,7 +13,6 @@ class XS1Thermostat(XS1Actuator):
     def set_temperature(self, temp: float) -> None:
         """
         Sets the new target temperature of this thermostat
-
         :param temp: new target temperature
         """
         response = self._api_interface.set_actuator_value(self.id(), temp)

--- a/xs1_api_client/device/sensor/__init__.py
+++ b/xs1_api_client/device/sensor/__init__.py
@@ -17,7 +17,7 @@ class XS1Sensor(XS1Device):
         """
         Updates the state of this sensor
         """
-        response = self._api_interface.get_state_sensor(self.id())
+        response = self._api_interface.get_state_sensor(self.number())
         new_value = self._get_node_value(response, Node.SENSOR)
         self.set_state(new_value)
 
@@ -31,7 +31,7 @@ class XS1Sensor(XS1Device):
         # check name arg for validity
         super(XS1Sensor, self).set_name(name)
 
-        config = self._api_interface.get_config_sensor(self.id())
+        config = self._api_interface.get_config_sensor(self.number())
 
         # name is already set, to minimize flash writes don't write it again
         if config["name"] == name:
@@ -39,7 +39,7 @@ class XS1Sensor(XS1Device):
 
         config["name"] = name
 
-        result = self._api_interface.set_config_sensor(self.id(), config)
+        result = self._api_interface.set_config_sensor(self.number(), config)
         new_name = self._get_node_value(result, "name")
 
         # save new_name to internal state
@@ -53,6 +53,6 @@ class XS1Sensor(XS1Device):
         This should only be used for debugging purpose!
         :param value: new value to set
         """
-        response = self._api_interface.set_sensor_value(self.id(), value)
+        response = self._api_interface.set_sensor_value(self.number(), value)
         new_value = self._get_node_value(response, Node.SENSOR)
         self.set_state(new_value)

--- a/xs1_api_client/device/sensor/__init__.py
+++ b/xs1_api_client/device/sensor/__init__.py
@@ -25,7 +25,6 @@ class XS1Sensor(XS1Device):
         """
         Sets a new name for this device.
         Keep in mind that there are some limitations for a device name.
-
         :param name: the new name to set
         :return: the new name of the sensor
         """


### PR DESCRIPTION
fixes #1 
This PR separates the ID and Number properties inside `XS1Device` to prevent changes in the order of the Web GUI to affect the order devices are updated.

The `id` property is a unique identifier that does **not** change even when swapping devices in the XS1 Web GUI using the "Austauschen" button.
The `number` property however **does** change when the position of a device is swapped with another one, so it can not be used for identification but only for ordering.

Note: for this change to propagate to Home Assistant a new release has to be incorporated.